### PR TITLE
Bump upper bounds for `transformers` dependency

### DIFF
--- a/pipes-group.cabal
+++ b/pipes-group.cabal
@@ -31,7 +31,7 @@ Library
         free         >= 3.2     && < 5  ,
         pipes        >= 4.0     && < 4.2,
         pipes-parse  >= 3.0.0   && < 3.1,
-        transformers >= 0.2.0.0 && < 0.4
+        transformers >= 0.2.0.0 && < 0.5
     Exposed-Modules:
         Pipes.Group
         Pipes.Group.Tutorial


### PR DESCRIPTION
This builds properly with a version of `free` where its dependencies have been updated for the new `transfomers` version. I already submitted the corresponding pull requests for `free` and its dependencies (`profunctors` and `either`).
